### PR TITLE
Fix write through smaller readbuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "queue-file"
-version = "1.4.2"
+version = "1.4.3"
 license = "Apache-2.0"
 authors = ["ING Systems <contact@ing-systems.com>"]
 description = "queue-file is a lightning-fast, transactional, file-based FIFO"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,8 +756,7 @@ impl QueueFile {
         if end_of_last_elem <= self.first.pos {
             count = end_of_last_elem - self.header_len;
 
-            let write_pos = self.inner.seek(orig_file_len)?;
-            self.inner.transfer(self.header_len, write_pos, count)?;
+            self.inner.transfer(self.header_len, self.file_len(), count)?;
         }
 
         // Commit the expansion.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -870,7 +870,8 @@ impl QueueFileInner {
             let read_buffered = read_buffer_offset..read_buffer_end_offset;
 
             let has_start = read_buffered.contains(&self.expected_seek);
-            let has_end = read_buffered.contains(&(self.expected_seek + write_size_u64));
+            let buf_end = self.expected_seek + write_size_u64;
+            let has_end = read_buffered.contains(&buf_end);
 
             match (has_start, has_end) {
                 // rd_buf_offset .. exp_seek .. exp_seek+buf.len .. rd_buf_end
@@ -893,6 +894,17 @@ impl QueueFileInner {
                     let need_to_copy = self.read_buffer.len() - need_to_skip;
                     self.read_buffer[need_to_skip..need_to_skip + need_to_copy]
                         .copy_from_slice(&buf[..need_to_copy]);
+                }
+                // exp_seek .. rd_buf_offset .. rd_buf_end .. exp_seek+buf.len
+                // read buffer is inside writing range, need to rewrite it completely
+                (false, false)
+                    if (self.expected_seek + 1..buf_end).contains(&read_buffer_offset) =>
+                {
+                    let need_to_skip = (read_buffer_offset - self.expected_seek) as usize;
+                    let need_to_copy = self.read_buffer.len();
+
+                    self.read_buffer[..]
+                        .copy_from_slice(&buf[need_to_skip..need_to_skip + need_to_copy]);
                 }
                 // nothing to do, read & write buffers do not overlap
                 (false, false) => {}

--- a/tests/bug_cases.rs
+++ b/tests/bug_cases.rs
@@ -12,3 +12,21 @@ fn reopen_bigger_capacity_wrong_file_len() {
     let qf = QueueFile::with_capacity(&path, 1024 * 6).unwrap();
     assert_eq!(std::fs::metadata(&path).unwrap().len(), qf.file_len());
 }
+
+#[test]
+fn bigger_write_buffer_overwrites_read_buffer() {
+    let path = auto_delete_path::AutoDeletePath::temp();
+    let mut qf = QueueFile::with_capacity(path, 32 + 4 * 2 + 2 + 4).unwrap();
+    qf.set_overwrite_on_remove(false);
+    qf.set_read_buffer_size(7);
+
+    qf.add_n(&[&[1, 2, 3], &[4, 5, 6]]).unwrap();
+    qf.remove().unwrap();
+    qf.remove().unwrap();
+
+    qf.add_n(&[&[7, 8, 9, 10][..], &[0, 0]]).unwrap();
+    qf.remove().unwrap();
+
+    qf.add(&[99]).unwrap();
+    qf.remove().unwrap();
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -56,9 +56,14 @@ enum Action {
 
 impl quickcheck::Arbitrary for Action {
     fn arbitrary(mut g: &mut quickcheck::Gen) -> Self {
-        let is_add = bool::arbitrary(&mut g);
+        let kind = u32::arbitrary(&mut g);
 
-        if is_add { Self::Add(Vec::arbitrary(g)) } else { Self::Remove(usize::arbitrary(g)) }
+        match kind % 3 {
+            0 => Self::Add(Vec::arbitrary(g)),
+            1 => Self::Remove(usize::arbitrary(g)),
+            2 => Self::Read { skip: usize::arbitrary(&mut g), take: usize::arbitrary(&mut g) },
+            _ => unreachable!(),
+        }
     }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {


### PR DESCRIPTION
For the certain cases where `write buffer size > read buffer size` on `write` it does not update the read buffer leading to the stale cache. That's only the case for add(_n)+remove(_n) combination, since the last one may use stale data.